### PR TITLE
Update license to reflect new ownership

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 egghead.io LLC
+Copyright (c) 2018-2019 Peter Keen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/egghea
 
 ## License
 
-Copyright (c) egghead.io LLC. The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+Copyright (c) Peter Keen. The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 

--- a/sequins.gemspec
+++ b/sequins.gemspec
@@ -7,11 +7,11 @@ Gem::Specification.new do |spec|
   spec.name          = "sequins"
   spec.version       = Sequins::VERSION
   spec.authors       = ["Pete Keen"]
-  spec.email         = ["pete@egghead.io"]
+  spec.email         = ["pete@petekeen.net"]
 
   spec.summary       = %q{Sequins allows you to define temporal sequences of actions}
   spec.description   = %q{Set up sequences of actions that are delayed in time}
-  spec.homepage      = "https://github.com/eggheadio/sequins"
+  spec.homepage      = "https://github.com/peterkeen/sequins"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Updating copyright and license statements to reflect transfer of ownership from egghead.io LLC to me personally.